### PR TITLE
Modify reject_empty_localization! for Rails 4.1.16

### DIFF
--- a/lib/has_localization_table/active_record/relation.rb
+++ b/lib/has_localization_table/active_record/relation.rb
@@ -94,11 +94,11 @@ module HasLocalizationTable
 
         # Remove localization objects that are not filled in
         def reject_empty_localizations!
-          without_rejected_records = localization_association.reject do |l|
+          without_empty_localizations = localization_association.reject do |l|
             !l.persisted? && localized_attributes.all?{ |attr| l.send(attr).blank? }
           end
 
-          localization_association.replace(without_rejected_records)
+          localization_association = without_empty_localizations
         end
       end
     end


### PR DESCRIPTION
With this change the order of primary/secondary language is preserved like in the screenshot below during an error on the form.

![talentnest](https://user-images.githubusercontent.com/1771310/35232667-14054760-ff6a-11e7-8d37-1256d51523ce.png)

If using `localization_association.replace(...)` then the secondary language (French) would be on the top on form error.

This change did require modification to the models/country_name_spec

`.last` instead of `.first`

```ruby
it 'should return the country names that have the abbreviation within the language given' do
   expect(CountryName.with_abbr(country.abbreviation, lang.id).to_a).to eq([country.country_names.last])
end
```

So maybe more work on `has_localization_table` will be needed. Lets see how it goes.
